### PR TITLE
npdf: re-implement recrop with qpdf and add fix-color command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -70,6 +79,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.71.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -115,7 +144,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90583009037521a116abf44494efecd645ba48b6622457080f080b85544e2215"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -132,6 +172,17 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -457,6 +508,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -526,16 +583,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom",
+ "libc",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -677,6 +763,7 @@ dependencies = [
  "inquire",
  "lopdf",
  "num_cpus",
+ "qpdf",
  "rayon",
  "sha2",
  "simple-jpegli-enc",
@@ -723,6 +810,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
 name = "png"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -745,12 +838,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "qpdf"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "591bfcfd27103ebb9c3252fdcde2f05b2c52a0afb38a73a741cd84ad28f3f133"
+dependencies = [
+ "libc",
+ "qpdf-sys",
+]
+
+[[package]]
+name = "qpdf-sys"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30721c95d1b8668a7225e53fd59ded9d8175d6d348915adb1ea6b3f3b305f434"
+dependencies = [
+ "bindgen",
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -837,6 +961,41 @@ checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "regex"
+version = "1.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ list all available images in the PDF files, can be used to help determine what y
 npdf export <pdf_file> <output_dir>
 ```
 
-export the PDF into `<output_dir>` as PNG images. Use `-h`/`--help` to see options (DPI, color mode, page ranges, etc.).
+export OR extract the PDF into `<output_dir>` as PNG images. Use `-h`/`--help` to see options (DPI, color mode, page ranges, etc.).
 
 by default `npdf export` spawns multiple workers (one per logical CPU).<br />
 pass `--threads 1` to run single-threaded or `--threads N` to clamp the worker count.
@@ -84,15 +84,11 @@ this is powered with [`jpegli`/`libjxl`](https://github.com/libjxl/libjxl) via [
 
 you can also use the `--cmyk-png` option to use CMYK as rendering color mode but still export as PNG (with color conversion to RGB/Gray).
 
-### extract
-```
-npdf extract <pdf_file> <output_dir>
-```
+previously, the `npdf extract` is their own command but has been merged into `npdf export` for simplicity.<br />
+to get the previous behavior of extract, use: `npdf export --extract all -o <output_dir> <pdf_file>`.
 
-extract all images embedded in the PDF file and save them into `<output_dir>`.<br />
-the images will be saved using their original format (png/jpg/tiff/etc.) if possible
-
-this command should be similar to `pdfimages` from poppler/xpdf.
+there is a new extract mode which is `--extract some` which do extraction if the page only contains single image that covers the whole page (like scanned pages).<br />
+this is useful for scanned PDFs that you want to extract the images directly instead of rendering them again (which may cause quality loss).
 
 ### unwatermark
 ```
@@ -118,6 +114,16 @@ recrop all pages in the PDF file using the specified crop mode and save the recr
 - `bleed`: use the BleedBox
 - `trim`: use the TrimBox
 - `art`: use the ArtBox
+
+this use [`qpdf-rs`](https://crates.io/crates/qpdf-rs) crate to manipulate the PDF file directly.
+
+### recrop
+```
+npdf fix-color -o <output_file> <pdf_file>
+```
+
+batch fix stencil pages to only use black/white for digital preservation/display and save the fixed PDF into `<output_file>`.<br />
+internally this use black Separation color space which works the best with our `export` command (which use poppler SplashOutput renderer).
 
 this use [`qpdf-rs`](https://crates.io/crates/qpdf-rs) crate to manipulate the PDF file directly.
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ recrop all pages in the PDF file using the specified crop mode and save the recr
 - `trim`: use the TrimBox
 - `art`: use the ArtBox
 
-this use [`lopdf`](https://crates.io/crates/lopdf) crate to manipulate the PDF file directly.
+this use [`qpdf-rs`](https://crates.io/crates/qpdf-rs) crate to manipulate the PDF file directly.
 
 ## other tools
 
@@ -131,14 +131,12 @@ see the [tools/README.md](./tools/README.md) for more info.
 
 this project is not affiliated with or endorsed by the poppler/xpdf project or its maintainers. use at your own risk.
 
-i also haven't ran `miri` yet on this since i need some example PDFs first that could help test some stuff.
-
 ## license
 
 GPL-3.0-or-later as the poppler/xpdf library is licensed in GPL
 
 ## acknowledgements
 
-- thanks to the poppler/xpdf project for their great rendering library for PDF files.
-- the libjxl project for the great JPEG compression library (especially the jpegli bridge).
-- the lopdf project for their PDF manipulation library.
+- thanks to the [poppler](https://poppler.freedesktop.org/)/xpdf project for their great rendering library for PDF files.
+- the [libjxl](https://github.com/libjxl/libjxl) project for the great JPEG compression library (especially the jpegli bridge).
+- the [qpdf](https://github.com/qpdf/qpdf) (and the [rust-binding](https://github.com/ancwrd1/qpdf-rs)) project for their PDF manipulation library.

--- a/npdf/Cargo.toml
+++ b/npdf/Cargo.toml
@@ -21,6 +21,7 @@ color-print.workspace = true
 tiny-poppler = { path = "../tiny-poppler" }
 simple-jpegli-enc = { path = "../simple-jpegli-enc" }
 lopdf.workspace = true
+qpdf = { version = "0.3.4", features = ["vendored"], default-features = false }
 sha2.workspace = true
 
 rayon.workspace = true

--- a/npdf/src/commands/export/mod.rs
+++ b/npdf/src/commands/export/mod.rs
@@ -291,8 +291,8 @@ fn should_be_extracted(page: &PageInfo, images: &[ImageInfo], mode: ExtractionMo
                 // if no images, render
                 false
             } else {
-                // if pdf/a compliant, extract
-                page.is_pdf_a_compatible
+                // if pdf/a compliant, extract if only single image that covers the whole page
+                page.is_pdf_a_compatible && images.len() == 1
             }
         }
     }

--- a/npdf/src/commands/fix_color.rs
+++ b/npdf/src/commands/fix_color.rs
@@ -1,0 +1,332 @@
+use clap::Args;
+use color_print::cprintln;
+use lopdf::{
+    Object,
+    content::{Content, Operation},
+};
+use qpdf::{
+    ObjectStreamMode, QPdfArray, QPdfDictionary, QPdfObject, QPdfObjectLike, QPdfObjectType,
+    QPdfStream, StreamDecodeLevel,
+};
+use std::{collections::HashSet, path::PathBuf};
+use tiny_poppler::PdfPasswords;
+
+use crate::common::open_maybe_locked;
+
+const CS_NAME: &str = "/PureBlackCS";
+
+#[derive(Args)]
+pub struct FixColorspaceArgs {
+    /// Path to the PDF file to fix colorspaces.
+    pub pdf: PathBuf,
+    /// Output file path to save the fixed PDF.
+    #[arg(short = 'o', long)]
+    pub output: PathBuf,
+}
+
+pub fn run(args: FixColorspaceArgs, passwords: Option<&PdfPasswords>) -> Result<(), String> {
+    if !args.pdf.exists() {
+        return Err(format!("PDF file does not exist: {}", args.pdf.display()));
+    }
+
+    cprintln!("<m,s>Loading PDF</>: {}", args.pdf.display());
+    // read PDF to bytes first to avoid multiple opens
+    let pdf_bytes = std::fs::read(&args.pdf)
+        .map_err(|err| format!("Failed to read PDF file {}: {}", args.pdf.display(), err))?;
+
+    let doc = open_maybe_locked(&pdf_bytes, passwords)?;
+    let total_pages = doc
+        .get_num_pages()
+        .map_err(|err| format!("Failed to get number of pages: {}", err))?;
+
+    // Make the colorspace
+    let tint_func_ty = doc.new_integer(2);
+    let tint_domain = doc.new_array_from(vec![
+        QPdfObject::from(doc.new_integer(0)),
+        QPdfObject::from(doc.new_integer(1)),
+    ]);
+    let tint_range = doc.new_array_from(vec![
+        QPdfObject::from(doc.new_integer(0)),
+        QPdfObject::from(doc.new_integer(1)),
+    ]);
+    let tint_c0 = doc.new_array_from(vec![QPdfObject::from(doc.new_real(1.0, 1))]);
+    let tint_c1 = doc.new_array_from(vec![QPdfObject::from(doc.new_real(0.0, 1))]);
+    let tint_n = doc.new_real(1.0, 1);
+
+    let tint_transform = doc.new_dictionary_from(vec![
+        ("/FunctionType", QPdfObject::from(tint_func_ty)),
+        ("/Domain", QPdfObject::from(tint_domain)),
+        ("/Range", QPdfObject::from(tint_range)),
+        ("/C0", QPdfObject::from(tint_c0)),
+        ("/C1", QPdfObject::from(tint_c1)),
+        ("/N", QPdfObject::from(tint_n)),
+    ]);
+
+    let separation_color = doc.new_array_from(vec![
+        doc.new_name("/Separation"),
+        doc.new_name("/All"),
+        doc.new_name("/DeviceGray"),
+        QPdfObject::from(tint_transform),
+    ]);
+
+    cprintln!("<m,s>Processing pages</>...");
+    for pg_num in 0..total_pages {
+        let page = doc
+            .get_page(pg_num)
+            .ok_or(format!("Page {} not found in document.", pg_num + 1))?;
+
+        if is_pure_stencil_page(&page)? {
+            cprintln!(
+                "<cyan>Page <bold>{}</bold></cyan>: Pure stencil page detected, applying fix...",
+                pg_num + 1
+            );
+            inplace_fix_colorspace(&doc, page, &separation_color)?;
+        }
+    }
+
+    cprintln!(
+        "<magenta,bold>Saving output PDF</>: {}",
+        args.output.display()
+    );
+
+    let pdf_version = doc.get_pdf_version();
+
+    doc.writer()
+        .static_id(false)
+        .force_pdf_version(&pdf_version)
+        .normalize_content(true)
+        .preserve_unreferenced_objects(false)
+        .compress_streams(true)
+        .object_stream_mode(ObjectStreamMode::Preserve)
+        .write(&args.output)
+        .map_err(|err| format!("Failed to save output PDF: {}", err))?;
+
+    Ok(())
+}
+
+fn is_pure_stencil_page(page: &QPdfDictionary) -> Result<bool, String> {
+    let mut safe_stencils: HashSet<NameDash> = HashSet::new();
+    let mut forbidden_objects: HashSet<NameDash> = HashSet::new();
+
+    if let Some(resources_obj) = page.get("/Resources")
+        && let Ok(resources_dict) = object_to_dictionary(resources_obj)
+        && let Some(xobjects_obj) = resources_dict.get("/XObject")
+        && let Ok(xobjects_dict) = object_to_dictionary(xobjects_obj)
+    {
+        for name in xobjects_dict.keys() {
+            let name = NameDash::from(name);
+            if let Some(xobj) = xobjects_dict.get(name.as_ref())
+                && let Ok(xobj_dict) = xobject_to_dictionary(xobj)
+                && let Some(subtype_obj) = xobj_dict.get("/Subtype")
+                && let Ok(subtype_name) = object_to_name(subtype_obj)
+            {
+                if subtype_name != "/Image" {
+                    forbidden_objects.insert(name);
+                } else {
+                    let is_image_mask = xobj_dict.has("/ImageMask");
+                    let has_smask = xobj_dict.has("/SMask");
+                    let has_mask = xobj_dict.has("/Mask");
+
+                    if is_image_mask && !has_smask && !has_mask {
+                        safe_stencils.insert(name);
+                    } else {
+                        forbidden_objects.insert(name);
+                    }
+                }
+            }
+        }
+    }
+
+    // load the contents
+    if let Some(contents_obj) = page.get("/Contents")
+        && let Ok(contents_stream) = object_to_stream(contents_obj)
+        && let Ok(content_data) = contents_stream.get_data(StreamDecodeLevel::All)
+    {
+        let content_data = Content::decode(&content_data)
+            .map_err(|err| format!("Failed to decode content stream: {}", err))?;
+
+        let mut has_drawn_stencil = false;
+        for op in content_data.operations {
+            if op.operator == "Do"
+                && let Some(operand_obj) = op.operands.first()
+                && let Ok(operand_name) = operand_obj.as_name()
+            {
+                let obj_name = NameDash::from(operand_name);
+                // found forbidden, just immediately return false
+                if forbidden_objects.contains(&obj_name) {
+                    return Ok(false);
+                }
+
+                if safe_stencils.contains(&obj_name) {
+                    has_drawn_stencil = true;
+                }
+            } else if op.operator == "BI" {
+                // inline image found, not pure stencil, quit early
+                return Ok(false);
+            }
+        }
+
+        Ok(has_drawn_stencil)
+    } else {
+        // failed to parse or no contents, assume not pure stencil
+        Ok(false)
+    }
+}
+
+fn inplace_fix_colorspace(
+    doc: &qpdf::QPdf,
+    page: QPdfDictionary,
+    colorspace: &QPdfArray,
+) -> Result<(), String> {
+    // first, inject the colorspace into the /Resources
+    let resources_obj = page
+        .get("/Resources")
+        .ok_or("Page missing /Resources dictionary.".to_string())?;
+    let resources_dict = object_to_dictionary(resources_obj)?;
+    let cs_dict = if let Some(cs_obj) = resources_dict.get("/ColorSpace") {
+        object_to_dictionary(cs_obj)?
+    } else {
+        doc.new_dictionary()
+    };
+    cs_dict.set(CS_NAME, colorspace);
+    resources_dict.set("/ColorSpace", cs_dict);
+
+    // Now, modify the content stream to use the new colorspace
+    let contents_obj = page
+        .get("/Contents")
+        .ok_or("Page missing /Contents stream.".to_string())?;
+    let contents_stream = object_to_stream(contents_obj)?;
+    let content_data = contents_stream
+        .get_data(StreamDecodeLevel::All)
+        .map_err(|err| format!("Failed to get content stream data: {}", err))?;
+    let content = Content::decode(&content_data)
+        .map_err(|err| format!("Failed to decode content stream: {}", err))?;
+
+    let mut is_before_cs = false;
+    let mut new_operations = Vec::new();
+    let cs_buffer = CS_NAME.as_bytes();
+    for op in content.operations {
+        if op.operator == "cs" || op.operator == "CS" {
+            // Replace the operand with our new colorspace
+            let new_op = Operation::new(&op.operator, vec![Object::Name(cs_buffer.to_vec())]);
+            new_operations.push(new_op);
+            is_before_cs = true;
+        } else if op.operator == "scn" || op.operator == "SCN" {
+            // Replace the operand with correct tint value
+            if !is_before_cs {
+                new_operations.push(op);
+                continue; // only modify if preceded by cs/CS
+            }
+
+            let new_op = Operation::new(&op.operator, vec![Object::Real(1.0)]); // Black is the default
+            new_operations.push(new_op);
+            is_before_cs = false;
+        } else {
+            is_before_cs = false;
+            new_operations.push(op);
+        }
+    }
+
+    let new_content = Content {
+        operations: new_operations,
+    };
+    let encoded_content = new_content
+        .encode()
+        .map_err(|err| format!("Failed to encode modified content stream: {}", err))?;
+
+    let content_dict = contents_stream.get_dictionary();
+    let content_filters = content_dict.get("/Filter").unwrap_or(doc.new_null());
+    let content_params = content_dict.get("/DecodeParms").unwrap_or(doc.new_null());
+    contents_stream.replace_data(encoded_content, content_filters, content_params);
+
+    // all done
+    Ok(())
+}
+
+fn object_to_dictionary(obj: QPdfObject) -> Result<QPdfDictionary, String> {
+    let kind = obj.get_type();
+    match kind {
+        QPdfObjectType::Dictionary => Ok(QPdfDictionary::from(obj)),
+        _ => Err(format!("Expected dictionary object, found {:?}", kind)),
+    }
+}
+
+fn object_to_stream(obj: QPdfObject) -> Result<QPdfStream, String> {
+    let kind = obj.get_type();
+    match kind {
+        QPdfObjectType::Stream => Ok(QPdfStream::from(obj)),
+        _ => Err(format!("Expected stream object, found {:?}", kind)),
+    }
+}
+
+fn object_to_name(obj: QPdfObject) -> Result<NameDash, String> {
+    let kind = obj.get_type();
+    match kind {
+        QPdfObjectType::Name => {
+            let name_str = obj.as_name();
+            Ok(NameDash::from(name_str))
+        }
+        _ => Err(format!("Expected name object, found {:?}", kind)),
+    }
+}
+
+fn xobject_to_dictionary(xobj: QPdfObject) -> Result<QPdfDictionary, String> {
+    let kind = xobj.get_type();
+    match kind {
+        QPdfObjectType::Stream => {
+            let stream = QPdfStream::from(xobj);
+            Ok(stream.get_dictionary())
+        }
+        QPdfObjectType::Dictionary => Ok(QPdfDictionary::from(xobj)),
+        _ => Err(format!(
+            "Expected XObject dictionary or stream, found {:?}",
+            kind
+        )),
+    }
+}
+
+#[derive(Debug, Clone)]
+struct NameDash(String);
+
+impl AsRef<str> for NameDash {
+    fn as_ref(&self) -> &str {
+        self.0.trim_start_matches('/')
+    }
+}
+
+impl From<&[u8]> for NameDash {
+    fn from(bytes: &[u8]) -> Self {
+        let s = String::from_utf8_lossy(bytes).into_owned();
+        NameDash(s)
+    }
+}
+
+impl From<&str> for NameDash {
+    fn from(s: &str) -> Self {
+        NameDash(s.to_string())
+    }
+}
+
+impl From<String> for NameDash {
+    fn from(s: String) -> Self {
+        NameDash(s)
+    }
+}
+
+impl PartialEq for NameDash {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_ref() == other.as_ref()
+    }
+}
+impl Eq for NameDash {}
+impl std::hash::Hash for NameDash {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.as_ref().hash(state);
+    }
+}
+
+impl PartialEq<&str> for NameDash {
+    fn eq(&self, other: &&str) -> bool {
+        self.as_ref() == other.trim_start_matches('/')
+    }
+}

--- a/npdf/src/commands/mod.rs
+++ b/npdf/src/commands/mod.rs
@@ -1,9 +1,11 @@
 pub mod export;
+pub mod fix_color;
 pub mod list;
 pub mod recrop;
 pub mod unwatermark;
 
 pub use export::ExportArgs;
+pub use fix_color::FixColorspaceArgs;
 pub use list::ListArgs;
 pub use recrop::RecropArgs;
 pub use unwatermark::UnwatermarkArgs;

--- a/npdf/src/commands/recrop.rs
+++ b/npdf/src/commands/recrop.rs
@@ -39,8 +39,11 @@ pub fn run(args: RecropArgs, passwords: Option<&PdfPasswords>) -> Result<(), Str
     };
 
     cprintln!("<m,s>Loading PDF</>: {}", args.pdf.display());
+    // read PDF to bytes first to avoid multiple opens
+    let pdf_bytes = std::fs::read(&args.pdf)
+        .map_err(|err| format!("Failed to read PDF file {}: {}", args.pdf.display(), err))?;
 
-    let doc = open_maybe_locked(&args.pdf, passwords)?;
+    let doc = open_maybe_locked(&pdf_bytes, passwords)?;
     let total_pages = doc
         .get_num_pages()
         .map_err(|err| format!("Failed to get number of pages: {}", err))?;

--- a/npdf/src/commands/recrop.rs
+++ b/npdf/src/commands/recrop.rs
@@ -1,10 +1,14 @@
+use std::path::PathBuf;
+
 use clap::{Args, ValueEnum};
 use color_print::{cformat, cprintln};
-use lopdf::{Document, Object, ObjectId};
-use std::path::PathBuf;
+use qpdf::{
+    ObjectStreamMode, QPdf, QPdfArray, QPdfDictionary, QPdfObject, QPdfObjectLike, QPdfObjectType,
+    QPdfScalar,
+};
 use tiny_poppler::PdfPasswords;
 
-use crate::common::{ensure_pdf_output, unlock_pdf};
+use crate::common::{ensure_pdf_output, open_maybe_locked};
 
 #[derive(Args)]
 pub struct RecropArgs {
@@ -34,39 +38,26 @@ pub fn run(args: RecropArgs, passwords: Option<&PdfPasswords>) -> Result<(), Str
         (None, false) => return Err("--output is required when not using --describe".into()),
     };
 
-    cprintln!("<magenta,bold>Loading PDF</>: {}", args.pdf.display());
-    let mut doc = Document::load(args.pdf).map_err(|err| err.to_string())?;
+    cprintln!("<m,s>Loading PDF</>: {}", args.pdf.display());
 
-    unlock_pdf(&doc, passwords)?;
+    let doc = open_maybe_locked(&args.pdf, passwords)?;
+    let total_pages = doc
+        .get_num_pages()
+        .map_err(|err| format!("Failed to get number of pages: {}", err))?;
 
-    // Check if encrypted and encryption state is still None (i.e., not yet authenticated)
-    let is_encrypted = doc.is_encrypted() && doc.encryption_state.is_none();
+    cprintln!("<m,s>Processing pages</>...");
 
-    match (passwords, is_encrypted) {
-        (Some(pwds), true) => {
-            if let Some(user_pwd) = &pwds.user {
-                doc.authenticate_password(user_pwd)
-                    .map_err(|err| err.to_string())?;
-            } else if let Some(owner_pwd) = &pwds.owner {
-                doc.authenticate_owner_password(owner_pwd)
-                    .map_err(|err| err.to_string())?;
-            }
-        }
-        (None, true) => {
-            return Err("PDF is encrypted but no passwords were provided.".to_string());
-        }
-        _ => {}
-    }
+    for pg_num in 0..total_pages {
+        let page = doc
+            .get_page(pg_num)
+            .ok_or(format!("Page {} not found in document.", pg_num + 1))?;
 
-    cprintln!("<magenta,bold>Processing pages</>...");
-    for (page_num, object_id) in doc.get_pages() {
-        let page_box = get_page_box(&doc, object_id)
-            .map_err(|err| format!("Failed to get page box for page {}: {}", page_num, err))?;
+        let page_box = get_page_box(&page)?;
 
         if args.describe {
             cprintln!(
                 " > <bold>Page <cyan>{page}</cyan></bold> ┆ {crop} ┆ {media} ┆ {art} ┆ {bleed} ┆ {trim} ┆ {orig}",
-                page = page_num,
+                page = pg_num,
                 crop = print_box("CropBox", page_box.cropbox),
                 media = print_box("MediaBox", page_box.mediabox),
                 art = print_box("ArtBox", page_box.artbox),
@@ -79,65 +70,48 @@ pub fn run(args: RecropArgs, passwords: Option<&PdfPasswords>) -> Result<(), Str
 
         match page_box.get_box(args.bounding) {
             Some(new_box) => {
-                set_new_crop_box(&mut doc, object_id, new_box).map_err(|err| {
-                    format!("Failed to set new crop box for page {}: {}", page_num, err)
+                set_new_crop_box(&doc, page, new_box, &page_box).map_err(|err| {
+                    format!(
+                        "Failed to set new crop box for page {}: {}",
+                        pg_num + 1,
+                        err
+                    )
                 })?;
-                cprintln!("<green>Recropped page</> {} to {:?}", page_num, new_box);
+                cprintln!("<green>Recropped page</> {} to {:?}", pg_num, new_box);
             }
             None => {
                 cprintln!(
                     "<yellow>Warning:</> Page {} does not have the specified box {:?}. Skipping.",
-                    page_num,
+                    pg_num,
                     args.bounding
                 );
             }
         }
     }
 
-    if args.describe {
-        return Ok(());
+    if let Some(output_path) = output {
+        cprintln!(
+            "<magenta,bold>Saving output PDF</>: {}",
+            output_path.display()
+        );
+
+        let pdf_version = doc.get_pdf_version();
+
+        doc.writer()
+            .static_id(false)
+            .force_pdf_version(&pdf_version)
+            .normalize_content(true)
+            .preserve_unreferenced_objects(false)
+            .compress_streams(true)
+            .object_stream_mode(ObjectStreamMode::Preserve)
+            .write(output_path)
+            .map_err(|err| format!("Failed to save output PDF: {}", err))?;
     }
 
-    let output_path = output
-        .as_ref()
-        .ok_or_else(|| "output path not set for non-describe mode".to_string())?;
-
-    cprintln!(
-        "<magenta,bold>Saving output PDF</>: {}",
-        output_path.display()
-    );
-    doc.save(output_path)
-        .map_err(|err| format!("Failed to save output PDF: {}", err))?;
-
-    cprintln!("<green,bold>Done!</>");
     Ok(())
 }
 
-struct PageBox {
-    cropbox: Option<[f32; 4]>,
-    mediabox: Option<[f32; 4]>,
-    artbox: Option<[f32; 4]>,
-    bleedbox: Option<[f32; 4]>,
-    trimbox: Option<[f32; 4]>,
-    old_cropbox: Option<[f32; 4]>,
-}
-
-impl PageBox {
-    fn get_box(&self, choice: CropChoice) -> Option<[f32; 4]> {
-        match choice {
-            // Always use old cropbox for recropping to CropBox
-            CropChoice::Crop => self.old_cropbox,
-            CropChoice::Media => self.mediabox,
-            CropChoice::Art => self.artbox,
-            CropChoice::Bleed => self.bleedbox,
-            CropChoice::Trim => self.trimbox,
-        }
-    }
-}
-
-fn get_page_box(doc: &Document, page_id: ObjectId) -> Result<PageBox, lopdf::Error> {
-    let page = doc.get_object(page_id).and_then(|o| o.as_dict())?;
-
+fn get_page_box(page: &QPdfDictionary) -> Result<PageBox, String> {
     let mut page_box = PageBox {
         cropbox: None,
         mediabox: None,
@@ -147,122 +121,183 @@ fn get_page_box(doc: &Document, page_id: ObjectId) -> Result<PageBox, lopdf::Err
         old_cropbox: None,
     };
 
-    if let Ok(cropbox) = page.get(b"CropBox").and_then(Object::as_array)
-        && cropbox.len() == 4
+    if let Some(cropbox) = page.get("/CropBox").and_then(|x| {
+        if x.get_type() == QPdfObjectType::Array {
+            Some(QPdfArray::from(x))
+        } else {
+            None
+        }
+    }) && cropbox.len() == 4
     {
-        let vals: [f32; 4] = [
-            f32_or_i64(&cropbox[0])?,
-            f32_or_i64(&cropbox[1])?,
-            f32_or_i64(&cropbox[2])?,
-            f32_or_i64(&cropbox[3])?,
+        let vals: [f64; 4] = [
+            object_to_f64(cropbox.get(0).ok_or("/CropBox missing first element")?)?,
+            object_to_f64(cropbox.get(1).ok_or("/CropBox missing second element")?)?,
+            object_to_f64(cropbox.get(2).ok_or("/CropBox missing third element")?)?,
+            object_to_f64(cropbox.get(3).ok_or("/CropBox missing fourth element")?)?,
         ];
+
         page_box.cropbox = Some(vals);
-    }
-    if let Ok(original_cropbox) = page.get(b"OriginalCropBox").and_then(Object::as_array)
-        && original_cropbox.len() == 4
+    };
+
+    if let Some(old_cropbox) = page.get("/OriginalCropBox").and_then(|x| {
+        if x.get_type() == QPdfObjectType::Array {
+            Some(QPdfArray::from(x))
+        } else {
+            None
+        }
+    }) && old_cropbox.len() == 4
     {
-        let vals: [f32; 4] = [
-            f32_or_i64(&original_cropbox[0])?,
-            f32_or_i64(&original_cropbox[1])?,
-            f32_or_i64(&original_cropbox[2])?,
-            f32_or_i64(&original_cropbox[3])?,
+        let vals: [f64; 4] = [
+            object_to_f64(
+                old_cropbox
+                    .get(0)
+                    .ok_or("/OriginalCropBox missing first element")?,
+            )?,
+            object_to_f64(
+                old_cropbox
+                    .get(1)
+                    .ok_or("/OriginalCropBox missing second element")?,
+            )?,
+            object_to_f64(
+                old_cropbox
+                    .get(2)
+                    .ok_or("/OriginalCropBox missing third element")?,
+            )?,
+            object_to_f64(
+                old_cropbox
+                    .get(3)
+                    .ok_or("/OriginalCropBox missing fourth element")?,
+            )?,
         ];
+
         page_box.old_cropbox = Some(vals);
-    }
-    if let Ok(mediabox) = page.get(b"MediaBox").and_then(Object::as_array)
-        && mediabox.len() == 4
+    };
+
+    if let Some(mediabox) = page.get("/MediaBox").and_then(|x| {
+        if x.get_type() == QPdfObjectType::Array {
+            Some(QPdfArray::from(x))
+        } else {
+            None
+        }
+    }) && mediabox.len() == 4
     {
-        let vals: [f32; 4] = [
-            f32_or_i64(&mediabox[0])?,
-            f32_or_i64(&mediabox[1])?,
-            f32_or_i64(&mediabox[2])?,
-            f32_or_i64(&mediabox[3])?,
+        let vals: [f64; 4] = [
+            object_to_f64(mediabox.get(0).ok_or("/MediaBox missing first element")?)?,
+            object_to_f64(mediabox.get(1).ok_or("/MediaBox missing second element")?)?,
+            object_to_f64(mediabox.get(2).ok_or("/MediaBox missing third element")?)?,
+            object_to_f64(mediabox.get(3).ok_or("/MediaBox missing fourth element")?)?,
         ];
+
         page_box.mediabox = Some(vals);
-    }
-    if let Ok(artbox) = page.get(b"ArtBox").and_then(Object::as_array)
-        && artbox.len() == 4
+    };
+
+    if let Some(artbox) = page.get("/ArtBox").and_then(|x| {
+        if x.get_type() == QPdfObjectType::Array {
+            Some(QPdfArray::from(x))
+        } else {
+            None
+        }
+    }) && artbox.len() == 4
     {
-        let vals: [f32; 4] = [
-            f32_or_i64(&artbox[0])?,
-            f32_or_i64(&artbox[1])?,
-            f32_or_i64(&artbox[2])?,
-            f32_or_i64(&artbox[3])?,
+        let vals: [f64; 4] = [
+            object_to_f64(artbox.get(0).ok_or("/ArtBox missing first element")?)?,
+            object_to_f64(artbox.get(1).ok_or("/ArtBox missing second element")?)?,
+            object_to_f64(artbox.get(2).ok_or("/ArtBox missing third element")?)?,
+            object_to_f64(artbox.get(3).ok_or("/ArtBox missing fourth element")?)?,
         ];
+
         page_box.artbox = Some(vals);
-    }
-    if let Ok(bleedbox) = page.get(b"BleedBox").and_then(Object::as_array)
-        && bleedbox.len() == 4
+    };
+
+    if let Some(bleedbox) = page.get("/BleedBox").and_then(|x| {
+        if x.get_type() == QPdfObjectType::Array {
+            Some(QPdfArray::from(x))
+        } else {
+            None
+        }
+    }) && bleedbox.len() == 4
     {
-        let vals: [f32; 4] = [
-            f32_or_i64(&bleedbox[0])?,
-            f32_or_i64(&bleedbox[1])?,
-            f32_or_i64(&bleedbox[2])?,
-            f32_or_i64(&bleedbox[3])?,
+        let vals: [f64; 4] = [
+            object_to_f64(bleedbox.get(0).ok_or("/BleedBox missing first element")?)?,
+            object_to_f64(bleedbox.get(1).ok_or("/BleedBox missing second element")?)?,
+            object_to_f64(bleedbox.get(2).ok_or("/BleedBox missing third element")?)?,
+            object_to_f64(bleedbox.get(3).ok_or("/BleedBox missing fourth element")?)?,
         ];
+
         page_box.bleedbox = Some(vals);
-    }
-    if let Ok(trimbox) = page.get(b"TrimBox").and_then(Object::as_array)
-        && trimbox.len() == 4
+    };
+
+    if let Some(trimbox) = page.get("/TrimBox").and_then(|x| {
+        if x.get_type() == QPdfObjectType::Array {
+            Some(QPdfArray::from(x))
+        } else {
+            None
+        }
+    }) && trimbox.len() == 4
     {
-        let vals: [f32; 4] = [
-            f32_or_i64(&trimbox[0])?,
-            f32_or_i64(&trimbox[1])?,
-            f32_or_i64(&trimbox[2])?,
-            f32_or_i64(&trimbox[3])?,
+        let vals: [f64; 4] = [
+            object_to_f64(trimbox.get(0).ok_or("/TrimBox missing first element")?)?,
+            object_to_f64(trimbox.get(1).ok_or("/TrimBox missing second element")?)?,
+            object_to_f64(trimbox.get(2).ok_or("/TrimBox missing third element")?)?,
+            object_to_f64(trimbox.get(3).ok_or("/TrimBox missing fourth element")?)?,
         ];
+
         page_box.trimbox = Some(vals);
-    }
+    };
 
     Ok(page_box)
 }
 
-fn set_new_crop_box(
-    doc: &mut Document,
-    page_id: ObjectId,
-    new_box: [f32; 4],
-) -> Result<(), lopdf::Error> {
-    // Get the old cropbox
-    let old_cropbox = {
-        let page = doc.get_object(page_id).and_then(|o| o.as_dict())?;
-        if let Ok(cropbox) = page.get(b"CropBox").and_then(Object::as_array) {
-            if cropbox.len() == 4 {
-                Some([
-                    cropbox[0].as_f32()?,
-                    cropbox[1].as_f32()?,
-                    cropbox[2].as_f32()?,
-                    cropbox[3].as_f32()?,
-                ])
-            } else {
-                None
-            }
-        } else {
-            None
+fn object_to_f64(obj: QPdfObject) -> Result<f64, String> {
+    match obj.get_type() {
+        QPdfObjectType::Integer => {
+            let int_val = QPdfScalar::from(obj).as_i64();
+            Ok(int_val as f64)
         }
-    };
+        QPdfObjectType::Real => {
+            let real_val = QPdfScalar::from(obj).as_f64();
+            Ok(real_val)
+        }
+        _ => Err(format!(
+            "Expected numeric object (Integer or Real), found {:?}",
+            obj.get_type()
+        )),
+    }
+}
 
-    let new_cropbox = Object::Array(vec![
-        Object::Real(new_box[0]),
-        Object::Real(new_box[1]),
-        Object::Real(new_box[2]),
-        Object::Real(new_box[3]),
+fn set_new_crop_box(
+    doc: &QPdf,
+    page: QPdfDictionary,
+    new_box: [f64; 4],
+    pagebox: &PageBox,
+) -> Result<(), String> {
+    let new_crop = doc.new_array_from([
+        f64_to_real(doc, new_box[0]),
+        f64_to_real(doc, new_box[1]),
+        f64_to_real(doc, new_box[2]),
+        f64_to_real(doc, new_box[3]),
     ]);
 
-    let page = doc.get_object_mut(page_id).and_then(|o| o.as_dict_mut())?;
-    page.set(b"CropBox", new_cropbox);
-    // check if have OriginalCropBox
-    let has_original_cropbox = page.get(b"OriginalCropBox").is_ok();
-    if !has_original_cropbox && let Some(old_box) = old_cropbox {
-        let original_cropbox = Object::Array(vec![
-            Object::Real(old_box[0]),
-            Object::Real(old_box[1]),
-            Object::Real(old_box[2]),
-            Object::Real(old_box[3]),
-        ]);
+    page.set("/CropBox", new_crop);
 
-        page.set(b"OriginalCropBox", original_cropbox);
+    if pagebox.old_cropbox.is_none()
+        && let Some(cropbox) = pagebox.cropbox
+    {
+        let original_crop = doc.new_array_from([
+            f64_to_real(doc, cropbox[0]),
+            f64_to_real(doc, cropbox[1]),
+            f64_to_real(doc, cropbox[2]),
+            f64_to_real(doc, cropbox[3]),
+        ]);
+        page.set("/OriginalCropBox", original_crop);
     }
+
     Ok(())
+}
+
+fn f64_to_real(doc: &QPdf, value: f64) -> QPdfObject {
+    let dec_places = value.fract().abs().log10().ceil() as u32;
+    doc.new_real(value, dec_places).into()
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, ValueEnum)]
@@ -274,18 +309,29 @@ pub enum CropChoice {
     Trim,
 }
 
-fn f32_or_i64(obj: &Object) -> Result<f32, lopdf::Error> {
-    match obj {
-        Object::Real(val) => Ok(*val),
-        Object::Integer(val) => Ok(*val as f32),
-        _ => Err(lopdf::Error::ObjectType {
-            expected: "Real or Integer",
-            found: obj.enum_variant(),
-        }),
+struct PageBox {
+    cropbox: Option<[f64; 4]>,
+    mediabox: Option<[f64; 4]>,
+    artbox: Option<[f64; 4]>,
+    bleedbox: Option<[f64; 4]>,
+    trimbox: Option<[f64; 4]>,
+    old_cropbox: Option<[f64; 4]>,
+}
+
+impl PageBox {
+    fn get_box(&self, choice: CropChoice) -> Option<[f64; 4]> {
+        match choice {
+            // Always use old cropbox for recropping to CropBox
+            CropChoice::Crop => self.old_cropbox,
+            CropChoice::Media => self.mediabox,
+            CropChoice::Art => self.artbox,
+            CropChoice::Bleed => self.bleedbox,
+            CropChoice::Trim => self.trimbox,
+        }
     }
 }
 
-fn print_box(box_name: &str, box_values: Option<[f32; 4]>) -> String {
+fn print_box(box_name: &str, box_values: Option<[f64; 4]>) -> String {
     if let Some(values) = box_values {
         cformat!(
             "<blue>{}</>: [{:.2}, {:.2}, {:.2}, {:.2}]",

--- a/npdf/src/common.rs
+++ b/npdf/src/common.rs
@@ -1,4 +1,5 @@
 use lopdf::Document;
+use qpdf::QPdf;
 use tiny_poppler::PdfPasswords;
 
 pub(crate) fn unlock_pdf(doc: &Document, passwords: Option<&PdfPasswords>) -> Result<(), String> {
@@ -31,4 +32,28 @@ pub(crate) fn ensure_pdf_output(output_path: &std::path::Path) -> Result<(), Str
         ));
     }
     Ok(())
+}
+
+pub(crate) fn open_maybe_locked(
+    path: &std::path::Path,
+    passwords: Option<&PdfPasswords>,
+) -> Result<QPdf, String> {
+    match passwords {
+        Some(pwds) => {
+            if let Some(user_pwd) = &pwds.user {
+                QPdf::read_encrypted(path, user_pwd)
+                    .map_err(|e| format!("Failed to open PDF with user password: {}", e))
+            } else if let Some(owner_pwd) = &pwds.owner {
+                QPdf::read_encrypted(path, owner_pwd)
+                    .map_err(|e| format!("Failed to open PDF with owner password: {}", e))
+            } else {
+                // no password provided, try without
+                QPdf::read(path).map_err(|e| format!("Failed to open PDF: {}", e))
+            }
+        }
+        None => {
+            // Try processing without a password
+            QPdf::read(path).map_err(|e| format!("Failed to open PDF: {}", e))
+        }
+    }
 }

--- a/npdf/src/common.rs
+++ b/npdf/src/common.rs
@@ -35,25 +35,25 @@ pub(crate) fn ensure_pdf_output(output_path: &std::path::Path) -> Result<(), Str
 }
 
 pub(crate) fn open_maybe_locked(
-    path: &std::path::Path,
+    buffers: &[u8],
     passwords: Option<&PdfPasswords>,
 ) -> Result<QPdf, String> {
     match passwords {
         Some(pwds) => {
             if let Some(user_pwd) = &pwds.user {
-                QPdf::read_encrypted(path, user_pwd)
+                QPdf::read_from_memory_encrypted(buffers, user_pwd)
                     .map_err(|e| format!("Failed to open PDF with user password: {}", e))
             } else if let Some(owner_pwd) = &pwds.owner {
-                QPdf::read_encrypted(path, owner_pwd)
+                QPdf::read_from_memory_encrypted(buffers, owner_pwd)
                     .map_err(|e| format!("Failed to open PDF with owner password: {}", e))
             } else {
                 // no password provided, try without
-                QPdf::read(path).map_err(|e| format!("Failed to open PDF: {}", e))
+                QPdf::read_from_memory(buffers).map_err(|e| format!("Failed to open PDF: {}", e))
             }
         }
         None => {
             // Try processing without a password
-            QPdf::read(path).map_err(|e| format!("Failed to open PDF: {}", e))
+            QPdf::read_from_memory(buffers).map_err(|e| format!("Failed to open PDF: {}", e))
         }
     }
 }

--- a/npdf/src/main.rs
+++ b/npdf/src/main.rs
@@ -10,7 +10,8 @@ use clap::{
 };
 use color_print::cprintln;
 use commands::{
-    ExportArgs, ListArgs, RecropArgs, UnwatermarkArgs, export, list, recrop, unwatermark,
+    ExportArgs, FixColorspaceArgs, ListArgs, RecropArgs, UnwatermarkArgs, export, fix_color, list,
+    recrop, unwatermark,
 };
 use tiny_poppler::PdfPasswords;
 
@@ -36,6 +37,7 @@ fn execute(cli: Cli) -> Result<(), String> {
         Commands::Export(args) => export::run(args, passwords.as_ref()),
         Commands::Unwatermark(args) => unwatermark::run(args, passwords.as_ref()),
         Commands::Recrop(args) => recrop::run(args, passwords.as_ref()),
+        Commands::FixColor(args) => fix_color::run(args, passwords.as_ref()),
         Commands::Version => cmd_show_version_info(),
     }
 }
@@ -70,6 +72,8 @@ enum Commands {
     Unwatermark(UnwatermarkArgs),
     /// Recrop pages in the PDF based on specified box.
     Recrop(RecropArgs),
+    /// Fix stencil page color issues in the PDF.
+    FixColor(FixColorspaceArgs),
     /// Get version information.
     Version,
 }


### PR DESCRIPTION
for recrop, it has been fully replaced by qpdf version which should be faster.
i was planning to also make unwatermark to use qpdf but it's kinda impossible since
i need to read all images and decode it properly and it's much harder to do.

i've also added new command called `fix-color` which is reimplemented
version of `pdf-separation-black.py` but in Rust, it use the same qpdf library.